### PR TITLE
Add External Authentication Providers (Google, Facebook , Microsoft)

### DIFF
--- a/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
+++ b/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
@@ -60,6 +60,14 @@ namespace SurveyBasket.DependencyInjection
                     facebookOptions.AppId = facebookAuthSection["AppId"]!;
                     facebookOptions.AppSecret = facebookAuthSection["AppSecret"]!;
 
+                })
+                .AddMicrosoftAccount(microsoftOptions =>
+                {
+                    IConfigurationSection microsoftAuthSection = configuration.GetSection("Authentication:Microsoft");
+
+                    microsoftOptions.ClientId = microsoftAuthSection["ClientId"]!;
+                    microsoftOptions.ClientSecret = microsoftAuthSection["ClientSecret"]!;
+
                 });
 
             return services;

--- a/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
+++ b/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
@@ -43,6 +43,16 @@ namespace SurveyBasket.DependencyInjection
             services.AddDistributedMemoryCache();
             services.AddHybridCache();
 
+            services.AddAuthentication()
+                .AddGoogle(options =>
+                {
+                    IConfigurationSection googleAuthSection = configuration.GetSection("Authentication:Google");
+
+                    options.ClientId = googleAuthSection["ClientId"]!;
+                    options.ClientSecret = googleAuthSection["ClientSecret"]!;
+
+                });
+
             return services;
         }
 

--- a/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
+++ b/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
@@ -43,13 +43,22 @@ namespace SurveyBasket.DependencyInjection
             services.AddDistributedMemoryCache();
             services.AddHybridCache();
 
+            /// -- Add External Authentication Providers (Google, Facebook , Microsoft)
             services.AddAuthentication()
-                .AddGoogle(options =>
+                .AddGoogle(googleOptions =>
                 {
                     IConfigurationSection googleAuthSection = configuration.GetSection("Authentication:Google");
 
-                    options.ClientId = googleAuthSection["ClientId"]!;
-                    options.ClientSecret = googleAuthSection["ClientSecret"]!;
+                    googleOptions.ClientId = googleAuthSection["ClientId"]!;
+                    googleOptions.ClientSecret = googleAuthSection["ClientSecret"]!;
+
+                })
+                .AddFacebook(facebookOptions =>
+                {
+                    IConfigurationSection facebookAuthSection = configuration.GetSection("Authentication:Facebook");
+
+                    facebookOptions.AppId = facebookAuthSection["AppId"]!;
+                    facebookOptions.AppSecret = facebookAuthSection["AppSecret"]!;
 
                 });
 

--- a/SurveyBasket.Api/SurveyBasket.Api.csproj
+++ b/SurveyBasket.Api/SurveyBasket.Api.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">

--- a/SurveyBasket.Api/SurveyBasket.Api.csproj
+++ b/SurveyBasket.Api/SurveyBasket.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />

--- a/SurveyBasket.Api/appsettings.json
+++ b/SurveyBasket.Api/appsettings.json
@@ -50,6 +50,10 @@
         "Facebook": {
             "AppId": "",
             "AppSecret": ""
+        },
+        "Microsoft": {
+            "ClientId": "",
+            "ClientSecret": ""
         }
 
     }

--- a/SurveyBasket.Api/appsettings.json
+++ b/SurveyBasket.Api/appsettings.json
@@ -41,7 +41,12 @@
         "Password": "",
         "Host": "smtp.ethereal.email",
         "Port": 587
+    },
+    "Authentication": {
+        "Google": {
+            "ClientId": "",
+            "ClientSecret": ""
+        }
+
     }
-
-
 }

--- a/SurveyBasket.Api/appsettings.json
+++ b/SurveyBasket.Api/appsettings.json
@@ -46,6 +46,10 @@
         "Google": {
             "ClientId": "",
             "ClientSecret": ""
+        },
+        "Facebook": {
+            "AppId": "",
+            "AppSecret": ""
         }
 
     }


### PR DESCRIPTION
#### PR Classification
New feature: Adds support for external authentication providers.

#### PR Summary
This pull request integrates Google, Facebook, and Microsoft external authentication into the application.
- DependencyInjection.cs: Registers and configures Google, Facebook, and Microsoft authentication services using configuration values.
- appsettings.json: Adds an "Authentication" section for storing credentials for each provider.
- SurveyBasket.Api.csproj: Adds NuGet packages for Google, Facebook, and Microsoft authentication.
