### PR TITLE
Dev

### DIFF
--- a/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
+++ b/SurveyBasket.Api/DependencyInjection/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Identity.UI.Services;
+﻿using Hangfire;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using SurveyBasket.Application.Abstractions.Settings;
 
 namespace SurveyBasket.DependencyInjection
@@ -34,6 +35,7 @@ namespace SurveyBasket.DependencyInjection
             // services.AddScoped<ICacheService, CacheService>(); // Not Applied Now , Hybrid Cache is applied
             services.AddExceptionHandler<GlobalExceptionHandler>();
             services.AddProblemDetails();
+            services.AddBackgroundJobsConfig(configuration);
 
             services.AddHttpContextAccessor();
 
@@ -49,7 +51,7 @@ namespace SurveyBasket.DependencyInjection
         public static IServiceCollection AddDatabaseServices(this IServiceCollection services, IConfiguration configuration)
         {
             var connectionString = configuration.GetConnectionString("DefaultConnection") ??
-                                  throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+                                  throw new InvalidOperationException("Connection string 'DefaultConnection' not founded");
             services.AddDbContext<AppDbContext>(options =>
               options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
             return services;
@@ -127,6 +129,18 @@ namespace SurveyBasket.DependencyInjection
 
             return services;
         }
+        public static IServiceCollection AddBackgroundJobsConfig(this IServiceCollection services,IConfiguration configuration)
+        { 
+            services.AddHangfire(config => config
+                .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+                .UseSimpleAssemblyNameTypeSerializer()
+                .UseRecommendedSerializerSettings()
+                .UseSqlServerStorage(configuration.GetConnectionString("HangfireConnection"))
+            );
 
+            services.AddHangfireServer();
+
+            return services;
+        }
     }
 }

--- a/SurveyBasket.Api/Program.cs
+++ b/SurveyBasket.Api/Program.cs
@@ -18,7 +18,6 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-
 }
 
 app.UseSerilogRequestLogging();

--- a/SurveyBasket.Api/Program.cs
+++ b/SurveyBasket.Api/Program.cs
@@ -1,3 +1,4 @@
+using Hangfire;
 using Serilog;
 using SurveyBasket.DependencyInjection;
 
@@ -17,11 +18,14 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+
 }
 
 app.UseSerilogRequestLogging();
 
 app.UseHttpsRedirection();
+
+app.UseHangfireDashboard("/jobs");
 
 app.UseCors();
 

--- a/SurveyBasket.Api/SurveyBasket.Api.csproj
+++ b/SurveyBasket.Api/SurveyBasket.Api.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.22" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.22" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />

--- a/SurveyBasket.Api/appsettings.json
+++ b/SurveyBasket.Api/appsettings.json
@@ -3,7 +3,8 @@
         "MinimumLevel": {
             "Default": "Information",
             "Override": {
-                "Microsoft.AspNetCore": "Warning"
+                "Microsoft.AspNetCore": "Warning",
+                "Hangfire": "Information"
             }
         },
         "WriteTo": [
@@ -27,7 +28,8 @@
     },
     "AllowedHosts": "*",
     "ConnectionStrings": {
-        "DefaultConnection": "Server = MUHAMMAD\\SQLEXPRESS;Database=SurveyBasketDb;Trusted_Connection=True;TrustServerCertificate=True;"
+        "DefaultConnection": "Server = MUHAMMAD\\SQLEXPRESS;Database=SurveyBasketDb;Trusted_Connection=True;TrustServerCertificate=True;",
+        "HangfireConnection": "Server = MUHAMMAD\\SQLEXPRESS;Database=SurveyBasketJobs;Trusted_Connection=True;TrustServerCertificate=True;"
     },
     "Jwt": {
         "Key": "",


### PR DESCRIPTION
This pull request introduces Hangfire to the project to enable background job processing. The main changes include adding Hangfire dependencies, configuring Hangfire with SQL Server storage, updating the dependency injection to include background job services, exposing the Hangfire dashboard, and updating configuration files to support these changes.

**Background job infrastructure:**
* Added Hangfire dependencies (`Hangfire.AspNetCore`, `Hangfire.Core`, `Hangfire.SqlServer`) to `SurveyBasket.Api.csproj` for background job processing.
* Implemented `AddBackgroundJobsConfig` extension method in `DependencyInjection.cs` to configure Hangfire with SQL Server storage using a new `HangfireConnection` connection string, and registered the Hangfire server.
* Registered the background job configuration in the main dependency injection setup by calling `services.AddBackgroundJobsConfig(configuration)`.

**Application startup and dashboard:**
* Added Hangfire to the program startup (`Program.cs`) and exposed the Hangfire dashboard at `/jobs`. [[1]](diffhunk://#diff-9aae4a8cfaf0f844b52d0cc329e3c50347e1a2fcda98a8a0627f14528f8b9be1R1) [[2]](diffhunk://#diff-9aae4a8cfaf0f844b52d0cc329e3c50347e1a2fcda98a8a0627f14528f8b9be1R27-R28)

**Configuration updates:**
* Added a new `HangfireConnection` string to `appsettings.json` for Hangfire's SQL Server storage, and updated Serilog logging to include Hangfire logs at the Information level. [[1]](diffhunk://#diff-91698b9410df345729ecff53ef4af1ef477c1dadeb9c5d093d72eae773899ad5L30-R32) [[2]](diffhunk://#diff-91698b9410df345729ecff53ef4af1ef477c1dadeb9c5d093d72eae773899ad5L6-R7)

**Other minor changes:**
* Minor change to the exception message when the default connection string is missing.